### PR TITLE
[Fix] generate_index_name에서 이름설정 변경

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ data:
 embedding:
     # openai 사용시 "text-embedding-3-small" 권장
     embed_model: "nlpai-lab/KoE5" #"sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", "openai", "cohere", "huggingface"
-    db_type: "chroma" # "faiss", "chorma"
+    db_type: "faiss" # "faiss", "chorma"
     vector_db_path: "data"
 
 retriever:

--- a/notebooks/embed_test.ipynb
+++ b/notebooks/embed_test.ipynb
@@ -462,16 +462,110 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "e548247e-8f19-4a69-9a46-63ea2283ddc7",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "os.chdir(\"..\")\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f0fb76c6-e0de-4a4e-85db-d01cb1999686",
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"LANGCHAIN_TRACING_V2\"] = \"true\"\n",
+    "os.environ[\"LANGCHAIN_PROJECT\"] = \"Codeit Project2\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d6630545-494c-4cc4-aa07-8f7e91bcdcf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LangSmith 추적을 시작합니다.\n",
+      "[프로젝트명]\n",
+      "Vectorstore_pinecone\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_teddynote import logging\n",
+    "logging.langsmith(\"Vectorstore_pinecone\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0b38fc6e-5456-414b-b604-95e4c3eccce5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LangSmith 추적을 하지 않습니다.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_teddynote import logging\n",
+    "\n",
+    "# set_enable=False 로 지정하면 추적을 하지 않습니다.\n",
+    "logging.langsmith(\"랭체인 튜토리얼 프로젝트\", set_enable=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6cb3da1f-2f6f-4152-860a-5619935c2f08",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "Exception",
+     "evalue": "The official Pinecone python package has been renamed from `pinecone-client` to `pinecone`. Please remove `pinecone-client` from your project dependencies and add `pinecone` instead. See the README at https://github.com/pinecone-io/pinecone-python-client for more information on using the python SDK.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mpinecone\u001b[39;00m\n",
+      "File \u001b[0;32m/opt/jhub-venv/lib/python3.10/site-packages/pinecone/__init__.py:5\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;124;03m.. include:: ../README.md\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m----> 5\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\n\u001b[1;32m      6\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe official Pinecone python package has been renamed from `pinecone-client` to `pinecone`. Please remove `pinecone-client` from your project dependencies and add `pinecone` instead. See the README at https://github.com/pinecone-io/pinecone-python-client for more information on using the python SDK.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      7\u001b[0m )\n",
+      "\u001b[0;31mException\u001b[0m: The official Pinecone python package has been renamed from `pinecone-client` to `pinecone`. Please remove `pinecone-client` from your project dependencies and add `pinecone` instead. See the README at https://github.com/pinecone-io/pinecone-python-client for more information on using the python SDK."
+     ]
+    }
+   ],
+   "source": [
+    "import pinecone"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0fb76c6-e0de-4a4e-85db-d01cb1999686",
+   "id": "09f4fbc7-13ee-4f3c-8ec5-a3583402830d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/embed_test.ipynb
+++ b/notebooks/embed_test.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "c20b65ee-4292-4e8e-87e1-b16e80a582cc",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/src/embedding/embedding_main.py
+++ b/src/embedding/embedding_main.py
@@ -28,7 +28,6 @@ def generate_index_name(config: dict) -> str:
         str: 자동 생성된 인덱스 이름 (예: all_100_recursive_openai_faiss_index)
     """
     data_type = config.get("data", {}).get("file_type", "all")
-    limit = config.get("data", {}).get("limit", 100)
     splitter = config.get("data", {}).get("splitter", "recursive")
     model = config.get("embedding", {}).get("embed_model", "default")
     db_type = config.get("embedding", {}).get("db_type", "faiss")
@@ -37,7 +36,7 @@ def generate_index_name(config: dict) -> str:
     model_key = model.split("/")[-1] if "/" in model else model
     model_key = model_key.replace('-', '_').replace(' ', '_')
 
-    return f"{data_type}_{limit}_{splitter}_{model_key}_{db_type}"
+    return f"{data_type}_{splitter}_{model_key}_{db_type}"
 
 
 def embedding_main(config: dict, chunks: List[Document]) -> Union[FAISS, Chroma]:


### PR DESCRIPTION
## ⛏ 작업 내용
- generate_index_name의 이름 설정 변경
- notebook에서 langsmith, pinecone 시도 


## 📌 PR Point


